### PR TITLE
Enforce use of "interact" key in the Godot Dialogue Manager

### DIFF
--- a/calm-before-the-storm/addons/dialogue_manager/dialogue_reponses_menu.gd
+++ b/calm-before-the-storm/addons/dialogue_manager/dialogue_reponses_menu.gd
@@ -134,7 +134,7 @@ func _on_response_gui_input(event: InputEvent, item: Control, response) -> void:
 
 	if event is InputEventMouseButton and event.is_pressed() and event.button_index == MOUSE_BUTTON_LEFT:
 		response_selected.emit(response)
-	elif event.is_action_pressed(&"ui_accept" if next_action.is_empty() else next_action) and item in get_menu_items():
+	elif event.is_action_pressed(&"interact" if next_action.is_empty() else next_action) and item in get_menu_items():
 		response_selected.emit(response)
 
 

--- a/calm-before-the-storm/addons/dialogue_manager/example_balloon/example_balloon.gd
+++ b/calm-before-the-storm/addons/dialogue_manager/example_balloon/example_balloon.gd
@@ -1,7 +1,7 @@
 extends CanvasLayer
 
 ## The action to use for advancing the dialogue
-@export var next_action: StringName = &"ui_accept"
+@export var next_action: StringName = &"interact"
 
 ## The action to use to skip typing the dialogue
 @export var skip_action: StringName = &"ui_cancel"


### PR DESCRIPTION
**Problem:**
We aren't using ui_accept which defaults to spacebar.

**Solution:**
This commit changes the use of example in gdscript. There is one more "ui_accept" that is mentioned in a .cs file but C# is not an option ATPIT.

[] Scripts Added
[] Scripts Modified
[] Scripts Removed
[] Scenes Added
[] Scenes Modified
[] Scenes Removed
[] Addons Added
[x] Addons Modified
[] Addons Removed
[] Assets Added
[] Assets Removed