### PR TITLE
Fix naming collisions for enum state

### DIFF
--- a/calm-before-the-storm/scenes/Player/MainPlayer.tscn
+++ b/calm-before-the-storm/scenes/Player/MainPlayer.tscn
@@ -606,7 +606,7 @@ animations = [{
 radius = 20.5356
 height = 141.994
 
-[node name="MainPlayer" type="Node2D"]
+[node name="MainPlayer" type="Node2D" groups=["Player"]]
 visibility_layer = 2
 y_sort_enabled = true
 
@@ -634,7 +634,6 @@ scale = Vector2(0.340872, 0.309872)
 gizmo_extents = 51.9
 
 [node name="InteractionArea" type="Area2D" parent="CharacterBody2D/PlayerDirection"]
-collision_layer = 0
 collision_mask = 512
 
 [node name="InteractionBox" type="CollisionShape2D" parent="CharacterBody2D/PlayerDirection/InteractionArea"]

--- a/calm-before-the-storm/scenes/Player/kplayer.tscn
+++ b/calm-before-the-storm/scenes/Player/kplayer.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=4 format=3 uid="uid://nt14wgqikh6k"]
 
-[ext_resource type="Script" path="res://scripts/BasicPlayer.gd" id="1_ok1p7"]
+[ext_resource type="Script" path="res://scripts/Player/BasicPlayer.gd" id="1_ok1p7"]
 [ext_resource type="Texture2D" uid="uid://4muc53oul7qb" path="res://icon.svg" id="2_lqhx6"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_6y0iu"]

--- a/calm-before-the-storm/scripts/NPC/npc_example_1.gd
+++ b/calm-before-the-storm/scripts/NPC/npc_example_1.gd
@@ -8,7 +8,7 @@ extends CharacterBody2D
 
 @onready var can_walk : bool = false
 
-enum State
+enum NPC_State
 {
 	IDLE,
 	WALK_NORTH,
@@ -23,19 +23,19 @@ enum State
 
 var ANIMATION_STATES : Dictionary = \
 {
-	State.IDLE : "standing",
-	State.WALK_NORTH : "walk_north",
-	State.WALK_NORTHEAST : "walk_northeast",
-	State.WALK_EAST : "walk_east",
-	State.WALK_SOUTHEAST : "walk_southeast",
-	State.WALK_SOUTH : "walk_south",
-	State.WALK_SOUTHWEST : "walk_southwest",
-	State.WALK_WEST : "walk_west",
-	State.WALK_NORTHWEST : "walk_northwest"
+	NPC_State.IDLE : "standing",
+	NPC_State.WALK_NORTH : "walk_north",
+	NPC_State.WALK_NORTHEAST : "walk_northeast",
+	NPC_State.WALK_EAST : "walk_east",
+	NPC_State.WALK_SOUTHEAST : "walk_southeast",
+	NPC_State.WALK_SOUTH : "walk_south",
+	NPC_State.WALK_SOUTHWEST : "walk_southwest",
+	NPC_State.WALK_WEST : "walk_west",
+	NPC_State.WALK_NORTHWEST : "walk_northwest"
 }
 
 var rng = RandomNumberGenerator.new()
-@onready var current_state : State = State.IDLE
+@onready var current_state : NPC_State = NPC_State.IDLE
 var npc_dialogue = null
 
 func _ready() -> void:
@@ -58,7 +58,7 @@ func choose_animation() -> void:
 		current_state = ANIMATION_STATES.keys()[rng_state]
 		next_animation = ANIMATION_STATES[current_state]
 	
-	if current_state == State.IDLE:
+	if current_state == NPC_State.IDLE:
 		can_walk = true
 	else:
 		can_walk = false


### PR DESCRIPTION
# **Problem:**
There was an issue with naming collisions for the **State** enum. This was due to an issue with the merges from previous PRs. 

# **Solution:**
- Kenny's implementation of enemy state and npc state is causing issues in
the namespace which is causing runtime issues. This commit renames State
in np_example_1 to NPC_STATE.
- The Main Player has been updated to be included in the **Player** group.

# CheckList
- [ ] Scripts Added
- [x] Scripts Modified
- [ ] Scripts Removed
- [ ] Scenes Added
- [x] Scenes Modified
- [ ] Scenes Removed
- [ ] Addons Added
- [ ] Addons Modified
- [ ] Addons Removed
- [ ] Assets Added
- [ ] Assets Removed
